### PR TITLE
Handle optional form fields in a cleaner way

### DIFF
--- a/src/Provider/FormServiceProvider.php
+++ b/src/Provider/FormServiceProvider.php
@@ -31,11 +31,7 @@ final class FormServiceProvider implements ServiceProviderInterface
         $container['form.kontact.max_message_length'] = 16384;
 
         $container['form.type.kontact'] = function (Container $container): KontactType {
-            return new KontactType(
-                $container['request_stack']->getCurrentRequest()->request->all(),
-                $container['form.kontact.max_message_length'],
-                $container['enable_captcha']
-            );
+            return new KontactType($container['form.kontact.max_message_length'], $container['enable_captcha']);
         };
 
         $container->extend('form.types', function (array $types, Container $container): array {


### PR DESCRIPTION
Hey @docteurklein,

So, following the advice you gave me yesterday, I did some tests, and the built-in `PATCH` method support in the Form component is neat! 👌 However, I’m not sure it totally applies to the current use case because&nbsp;:

1. conceptually, the `PATCH` method would normally be used to partially modify an existing resource, but here we are actually kind of creating a resource, so `POST` may seem more appropriate&nbsp;;
2. the `message` field must **always** be present in the request (only the 2 other fields are optional), and using `PATCH` would allow the client to bypass this requirement.

That being said, I still managed to refactor the code a bit to provide a cleaner solution (hopefully). I’d be glad to hear your feedback about it. 👍

Thanks!